### PR TITLE
Update mood sol full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Now it is time to create a solidity smart contract.
    ```
 
    - And that's it! your code
-     like [this](https://github.com/BlockDevsUnited/BasicFrontEndTutorial/blob/master/contracts/mood.sol)
+     like [this](https://github.com/LearnWeb3DAO/BasicFrontEndTutorial/blob/master/contracts/mood.sol)
 
 6. Deploy the contract on the Ropsten Testnet.
    - Make sure your Metamask is connected to the Ropsten Testnet.

--- a/contracts/mood.sol
+++ b/contracts/mood.sol
@@ -1,5 +1,5 @@
 //specify the version of solidity
-pragma solidity ^0.4.24;
+pragma solidity ^0.8.1;
 
 /// a simple set and get function for mood defined: 
 
@@ -10,12 +10,12 @@ contract MoodDiary{
     string mood;
     
     //create a function that writes a mood to the smart contract
-    function setMood(string _mood) public{
+    function setMood(string memory _mood) public{
         mood = _mood;
     }
     
     //create a function the reads the mood from the smart contract
-    function getMood() public view returns(string){
+    function getMood() public view returns(string memory){
         return mood;
     }
 }


### PR DESCRIPTION
When I was doing the track I was first copy code from mood.sol from the `README.md` and later I replaced some parts using the `contracts/mood.sol`. This way, i end up having solidity version `^0.8.1` without using  `memory` after `string`. 

I think it this confusing that the full example uses a different version than the readme. 
I also saw the full example is still linked to the fork base https://github.com/BlockDevsUnited/. So i changed it to https://github.com/LearnWeb3DAO

