### PR TITLE
Add SPDX-License and remove `memory` keyword

### DIFF
--- a/contracts/mood.sol
+++ b/contracts/mood.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 //specify the version of solidity
-pragma solidity ^0.8.1;
+pragma solidity ^0.8.15;
 
 /// a simple set and get function for mood defined: 
 

--- a/contracts/mood.sol
+++ b/contracts/mood.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //specify the version of solidity
 pragma solidity ^0.8.1;
 
@@ -10,12 +12,12 @@ contract MoodDiary{
     string mood;
     
     //create a function that writes a mood to the smart contract
-    function setMood(string memory _mood) public{
+    function setMood(string _mood) public{
         mood = _mood;
     }
     
     //create a function the reads the mood from the smart contract
-    function getMood() public view returns(string memory){
+    function getMood() public view returns(string){
         return mood;
     }
 }


### PR DESCRIPTION
- **Why `memory` keyword was removed ?**

```diff
- TypeError: Data location can only be specified for array, struct or mapping types,
- but "memory" was given.
````